### PR TITLE
Update vectorizer output path in `preprocess_train`

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,5 +2,5 @@
 
 ### Installation & Usage
 
-1. To install the `lib-ml` package, run the following command: `pip install git+https://github.com/remla25-team21/lib-ml.git@v0.0.5` (check latest release version)
+1. To install the `lib-ml` package, run the following command: `pip install git+https://github.com/remla25-team21/lib-ml.git@v0.0.6` (check latest release version)
 2. Once installed, you can use the pre-processing methods by importing them into your code: `from libml.preprocessing import preprocess_train, preprocess_inference`

--- a/src/libml/preprocessing.py
+++ b/src/libml/preprocessing.py
@@ -10,7 +10,7 @@ import pickle
 
 
 # Model Training
-def preprocess_train(dataset_filepath, test_size, random_state):
+def preprocess_train(dataset_filepath, test_size, random_state, vectorizer_output="c1_BoW_Sentiment_Model.pkl"):
     dataset = pd.read_csv(dataset_filepath, delimiter='\t', quoting=3)
     corpus = clean(dataset)
     cv = CountVectorizer(max_features=1420)
@@ -18,8 +18,7 @@ def preprocess_train(dataset_filepath, test_size, random_state):
     X = cv.fit_transform(corpus).toarray()
     y = dataset.iloc[:, -1].values
 
-    bow_path = '../c1_BoW_Sentiment_Model.pkl'
-    pickle.dump(cv, open(bow_path, "wb"))
+    pickle.dump(cv, open(vectorizer_output, "wb"))
 
     X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=test_size, random_state=random_state)
     return X_train, X_test, y_train, y_test


### PR DESCRIPTION
- Added `vectorizer_output` parameter to `preprocess_train()` to allow callers to control where the `CountVectorizer` is saved. 
- Replaced save path (`../c1_BoW_Sentiment_Model.pkl`) with a default local path (`c1_BoW_Sentiment_Model.pkl`). 